### PR TITLE
[FEATURE] Rename all references to necronizer's cloud to YASM Media

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,14 +23,14 @@ on:
 
 jobs:
   build_push_image:
-    name: Building and storing PhotoAtom Runner Docker Image
+    name: Building and storing YASM Runner Docker Image
     uses: necro-cloud/automations/.github/workflows/build-docker-image.yml@main
     with:
       dev_version_name: development
       image_name: runner
       image_proper_name: Self Hosted GitHub Runner
       build_path: .
-      repository: necronizerslab
+      repository: yasm
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test_communication:
     name: Testing Communication with Self Hosted Kubernetes Cluster
-    runs-on: [self-hosted, linux, cloud]
+    runs-on: [self-hosted, linux, yasm]
     env:
       KUBECONFIG: '/tmp/kubernetes/config.yml'
       KUBECONFIG_FOLDER: '/tmp/kubernetes'

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:24.10
 
 # Runner version to be used.
-ARG RUNNER_VERSION="2.322.0"
+ARG RUNNER_VERSION="2.323.0"
 
 # Accept default answers for all commands
 ENV DEBIAN_FRONTEND=noninteractive

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 PhotoAtom
+Copyright (c) 2025 YASM Media
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# necronizer's cloud self hosted github runners
+# YASM Media self hosted github runners
 
-This repository contains scripts, Dockerfile and Compose files for running Self Hosted GitHub Runners mainly to communicate with the [self hosted kubernetes cluster](https://github.com/necro-cloud/kubernetes).
+This repository contains scripts, Dockerfile and Compose files for running Self Hosted GitHub Runners mainly to communicate with the [self hosted kubernetes cluster](https://github.com/YASM-Media/cluster).
 
 # Requirements and Dependencies
 
 The following is required to start using this repository:
-1. [Docker and Docker Compose](https://www.docker.com/) - Required to run the self hosted runner as a container.
+1. [Podman and Podman Compose](https://podman.io/) - Required to run the self hosted runner as a container.
 
 # Usage Instructions
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   runners:
-    image: quay.io/necronizerslab/runner:0.25.26
+    image: quay.io/yasm/runner:0.1.2
     env_file:
       - runner.env
     networks:
@@ -8,5 +8,5 @@ services:
 
 networks:
   k3d_network:
-    name: k3d-cloud
+    name: k3d-yasm
     external: true

--- a/runner.env.example
+++ b/runner.env.example
@@ -1,4 +1,4 @@
-GH_ORG="necro-cloud"
-GH_RUNNER_NAME_PATTERN="cloud-runner"
+GH_ORG="YASM-Media"
+GH_RUNNER_NAME_PATTERN="yasm-runner"
 GH_TOKEN="<YOUR GITHUB TOKEN HERE>"
-GH_LABELS="cloud"
+GH_LABELS="yasm"

--- a/up.sh
+++ b/up.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-docker compose up -d --scale runners=3
+podman compose up -d --scale runners=3


### PR DESCRIPTION
# Proposed Changes
 - Renamed all references to necronizer's cloud to YASM Media in the README
 - Moved commands to Podman instead of using Docker
 - Setup `runner.env` to better reflect YASM Media

**Closes: #1**
